### PR TITLE
Convert to static initialization

### DIFF
--- a/app/src/main/java/com/example/draftt/onboarding/OnboardingPagerFragment.kt
+++ b/app/src/main/java/com/example/draftt/onboarding/OnboardingPagerFragment.kt
@@ -41,11 +41,11 @@ class OnboardingPagerFragment : Fragment() {
         }
 
         override fun createFragment(position: Int): Fragment {
-            return OnboardingScreenFragment(position)
+            return OnboardingScreenFragment.newInstance(position = position)
         }
     }
 
     companion object {
-        const val ONBOARDING_SLIDES = 3
+        private const val ONBOARDING_SLIDES = 3
     }
 }

--- a/app/src/main/java/com/example/draftt/onboarding/OnboardingScreenFragment.kt
+++ b/app/src/main/java/com/example/draftt/onboarding/OnboardingScreenFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import com.example.draftt.auth.LoginActivity
 import com.example.draftt.databinding.OnboardingSlide1Binding
@@ -12,7 +13,9 @@ import com.example.draftt.databinding.OnboardingSlide2Binding
 import com.example.draftt.databinding.OnboardingSlide3Binding
 import timber.log.Timber
 
-class OnboardingScreenFragment(private val position: Int) : Fragment() {
+class OnboardingScreenFragment() : Fragment() {
+
+    private val position by lazy { arguments!!.getInt(POSITION_KEY) }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -38,5 +41,15 @@ class OnboardingScreenFragment(private val position: Int) : Fragment() {
         Timber.d("Starting Login Activity")
         val intent = Intent(activity, LoginActivity::class.java)
         startActivity(intent)
+    }
+
+    companion object {
+        private const val POSITION_KEY = "position"
+
+        fun newInstance(position: Int) = OnboardingScreenFragment().apply {
+            arguments = bundleOf(
+                POSITION_KEY to position
+            )
+        }
     }
 }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -10,4 +10,8 @@
         android:name="com.example.draftt.onboarding.OnboardingPagerFragment"
         android:label="OnboardingFragment"
         tools:layout="@layout/onboarding_fragment_layout" />
+    <fragment
+        android:id="@+id/onboardingScreenFragment"
+        android:name="com.example.draftt.onboarding.OnboardingScreenFragment"
+        android:label="OnboardingScreenFragment" />
 </navigation>


### PR DESCRIPTION
Add a `newInstance` method for `OnboardingScreenFragment`. This is the best-practice method for creating Fragments. The reason for this is that we want to keep the constructors of Fragments zero parameter constructors. Android creates fragments behind the scenes using a zero-param constructor and we don't want the app to go kaboom if that happens. 

It definitely will go kaboom if we initialize our Fragments using non-zero param constructors and fail to provide a zero-param constructor -- not the mention the pain of keeping things 'consistent' between a fragment created by the non-zero param and zero param constructors

Closes #16 