### PR TITLE
Add firestore

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,12 +64,13 @@ dependencies {
     kapt "com.google.dagger:hilt-compiler:$hilt_version"
 
     // Import the Firebase BoM
-    implementation platform('com.google.firebase:firebase-bom:27.0.0')
+    implementation platform('com.google.firebase:firebase-bom:27.1.0')
 
     // Add the dependency for the Firebase SDK for Google Analytics
     // When using the BoM, don't specify versions in Firebase dependencies
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-auth-ktx'
+    implementation 'com.google.firebase:firebase-firestore-ktx'
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,11 @@ android {
 
 dependencies {
 
+    // Coroutines
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.4.1'
+
+
     // Room stuff
     implementation "androidx.room:room-runtime:2.3.0"
     kapt "androidx.room:room-compiler:2.3.0"
@@ -107,6 +112,5 @@ dependencies {
 
     // Logging library
     implementation 'com.jakewharton.timber:timber:4.7.1'
-
 
 }

--- a/app/src/main/java/com/aa/draftt/auth/repositories/AuthRepository.kt
+++ b/app/src/main/java/com/aa/draftt/auth/repositories/AuthRepository.kt
@@ -12,8 +12,6 @@ interface AuthRepository {
 
     fun currentUser(): FirebaseUser?
 
-    suspend fun writeUserToDatabase(name: String, email: String)
-
     // TODO: Add logging when implement this properly
     suspend fun signout()
 }

--- a/app/src/main/java/com/aa/draftt/auth/repositories/AuthRepository.kt
+++ b/app/src/main/java/com/aa/draftt/auth/repositories/AuthRepository.kt
@@ -4,6 +4,7 @@ import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.QuerySnapshot
 
 interface AuthRepository {
 
@@ -13,6 +14,9 @@ interface AuthRepository {
 
     // This will go into a FireStoreRepo
     suspend fun writeToFirestore(name: String, email: String): Task<DocumentReference>
+
+    // This will go into a FireStoreRepo
+    suspend fun getFromFirestore(email: String): Task<QuerySnapshot>
 
     suspend fun currentUser(): FirebaseUser?
 

--- a/app/src/main/java/com/aa/draftt/auth/repositories/AuthRepository.kt
+++ b/app/src/main/java/com/aa/draftt/auth/repositories/AuthRepository.kt
@@ -3,6 +3,7 @@ package com.aa.draftt.auth.repositories
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.DocumentReference
 
 interface AuthRepository {
 
@@ -10,7 +11,10 @@ interface AuthRepository {
 
     suspend fun signup(email: String, password: String): Task<AuthResult>
 
-    fun currentUser(): FirebaseUser?
+    // This will go into a FireStoreRepo
+    suspend fun writeToFirestore(name: String, email: String): Task<DocumentReference>
+
+    suspend fun currentUser(): FirebaseUser?
 
     // TODO: Add logging when implement this properly
     suspend fun signout()

--- a/app/src/main/java/com/aa/draftt/auth/repositories/AuthRepository.kt
+++ b/app/src/main/java/com/aa/draftt/auth/repositories/AuthRepository.kt
@@ -18,7 +18,7 @@ interface AuthRepository {
     // This will go into a FireStoreRepo
     suspend fun getFromFirestore(email: String): Task<QuerySnapshot>
 
-    suspend fun currentUser(): FirebaseUser?
+    suspend fun getLoggedInUser(): FirebaseUser?
 
     // TODO: Add logging when implement this properly
     suspend fun signout()

--- a/app/src/main/java/com/aa/draftt/auth/repositories/FirebaseAuthRepository.kt
+++ b/app/src/main/java/com/aa/draftt/auth/repositories/FirebaseAuthRepository.kt
@@ -54,7 +54,7 @@ class FirebaseAuthRepository @Inject constructor(
         }
     }
 
-    override suspend fun currentUser(): FirebaseUser? {
+    override suspend fun getLoggedInUser(): FirebaseUser? {
         // when we're asked for the current user, we should try to get
         // firebase Auth user
         // If that is not null, go to Firestore and grab the user info

--- a/app/src/main/java/com/aa/draftt/auth/repositories/FirebaseAuthRepository.kt
+++ b/app/src/main/java/com/aa/draftt/auth/repositories/FirebaseAuthRepository.kt
@@ -1,8 +1,11 @@
 package com.aa.draftt.auth.repositories
 
 import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -10,13 +13,13 @@ import javax.inject.Inject
 
 class FirebaseAuthRepository @Inject constructor(
     private val firebaseAuth: FirebaseAuth,
-    private val firebaseFirestore: FirebaseFirestore
+    private val firestore: FirebaseFirestore
 ) : AuthRepository {
 
     override suspend fun login(
         email: String,
         password: String
-    ): Task<com.google.firebase.auth.AuthResult> {
+    ): Task<AuthResult> {
         return withContext(Dispatchers.IO) {
             firebaseAuth.signInWithEmailAndPassword(email, password)
         }
@@ -25,15 +28,31 @@ class FirebaseAuthRepository @Inject constructor(
     override suspend fun signup(
         email: String,
         password: String
-    ): Task<com.google.firebase.auth.AuthResult> {
+    ): Task<AuthResult> {
         return withContext(Dispatchers.IO) {
             firebaseAuth.createUserWithEmailAndPassword(email, password)
         }
     }
 
-    override fun currentUser(): FirebaseUser? {
-        // Need to figure out if we want to return user from firebase or local cache
-        return firebaseAuth.currentUser
+    override suspend fun writeToFirestore(name: String, email: String): Task<DocumentReference> {
+
+        return withContext(Dispatchers.IO){
+            // write to firestore
+            val userData = hashMapOf(
+                "name" to name,
+                "email" to email
+            )
+            firestore.collection("users").add(userData)
+        }
+    }
+
+    override suspend fun currentUser(): FirebaseUser? {
+        // when we're asked for the current user, we should try to get
+        // firebase Auth user
+        // If that is not null, go to Firestore and grab the user info
+        return withContext(Dispatchers.IO){
+            firebaseAuth.currentUser
+        }
     }
 
     // TODO: Add logging when implement this properly

--- a/app/src/main/java/com/aa/draftt/auth/repositories/FirebaseAuthRepository.kt
+++ b/app/src/main/java/com/aa/draftt/auth/repositories/FirebaseAuthRepository.kt
@@ -1,32 +1,17 @@
 package com.aa.draftt.auth.repositories
 
-import com.aa.draftt.room.dao.UserDao
-import com.aa.draftt.room.models.User
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class FirebaseAuthRepository @Inject constructor(
     private val firebaseAuth: FirebaseAuth,
-    private val userDao: UserDao
+    private val firebaseFirestore: FirebaseFirestore
 ) : AuthRepository {
-
-    /*
-    *    In this repo, we need to do two things
-    *       - Call the requested function from the ViewModel
-    *       - if it's a success, put the UserInfo in the database (on Signup)
-    *           or grab user info (on Login)
-    *
-    *    OR
-    *      we can just expose a function that will write user info to the
-    *
-    *
-    *   Question that i failed to ask myself, why must the User be saved in Room?
-    *   cus when the app is killed, the in-memory stuff is gone. We need to retrieve user info
-    */
 
     override suspend fun login(
         email: String,
@@ -43,15 +28,6 @@ class FirebaseAuthRepository @Inject constructor(
     ): Task<com.google.firebase.auth.AuthResult> {
         return withContext(Dispatchers.IO) {
             firebaseAuth.createUserWithEmailAndPassword(email, password)
-        }
-    }
-
-    override suspend fun writeUserToDatabase(
-        name: String,
-        email: String
-    ){
-        withContext(Dispatchers.IO){
-            userDao.insert(User(name = name, email = email))
         }
     }
 

--- a/app/src/main/java/com/aa/draftt/auth/repositories/FirebaseAuthRepository.kt
+++ b/app/src/main/java/com/aa/draftt/auth/repositories/FirebaseAuthRepository.kt
@@ -55,9 +55,7 @@ class FirebaseAuthRepository @Inject constructor(
     }
 
     override suspend fun getLoggedInUser(): FirebaseUser? {
-        // when we're asked for the current user, we should try to get
-        // firebase Auth user
-        // If that is not null, go to Firestore and grab the user info
+        // Get currentUser from Firebase to check if user is logged in or not
         return withContext(Dispatchers.IO){
             firebaseAuth.currentUser
         }

--- a/app/src/main/java/com/aa/draftt/auth/repositories/FirebaseAuthRepository.kt
+++ b/app/src/main/java/com/aa/draftt/auth/repositories/FirebaseAuthRepository.kt
@@ -7,6 +7,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.QuerySnapshot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -43,6 +44,13 @@ class FirebaseAuthRepository @Inject constructor(
                 "email" to email
             )
             firestore.collection("users").add(userData)
+        }
+    }
+
+    override suspend fun getFromFirestore(email: String): Task<QuerySnapshot> {
+        return withContext(Dispatchers.IO) {
+            // get data from Firestore
+            firestore.collection("users").whereEqualTo("email", email).limit(1).get()
         }
     }
 

--- a/app/src/main/java/com/aa/draftt/auth/viewmodels/AuthViewModel.kt
+++ b/app/src/main/java/com/aa/draftt/auth/viewmodels/AuthViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.aa.draftt.models.AuthResult
 import com.aa.draftt.models.UserModel
 import com.aa.draftt.auth.repositories.AuthRepository
+import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.firestore.FirebaseFirestoreException
@@ -35,7 +36,7 @@ class AuthViewModel @Inject constructor(private val authRepository: AuthReposito
         get() = _authResult
 
     // Store user info using our model
-    private val _user = MutableLiveData<UserModel>()
+    private val _user = MutableLiveData(UserModel())
     val user: LiveData<UserModel>
         get() = _user
 
@@ -51,26 +52,45 @@ class AuthViewModel @Inject constructor(private val authRepository: AuthReposito
 
 
     fun login(email: String, password: String) {
-        viewModelScope.launch(Dispatchers.IO) {
-            val task = authRepository.login(email, password)
-            task.addOnCompleteListener {
-                if (task.isSuccessful) {
-                    Timber.d("Successfully logged in user with email: $email")
-                    // Instead of posting the value of it.result!!.user, we need to get it from db
-                    _firebaseUser.postValue(it.result!!.user)
-                    _authResult.postValue(AuthResult(status = true, error = null))
 
-                } else {
-                    Timber.d("Failed to log in user with email: $email")
-                    _firebaseUser.postValue(null)
-                    _authResult.postValue(
-                        AuthResult(
-                            status = false,
-                            error = task.exception?.localizedMessage.toString()
-                        )
-                    )
-                }
+        /*
+        * Similar to Signup, first we attempt a login, then we get some info from fireStore
+        * */
+
+        viewModelScope.launch(Dispatchers.IO) {
+            val loginTask = authRepository.login(email, password)
+            try {
+                Tasks.await(loginTask)
+                Timber.d("Successfully logged in user with email: $email")
+            } catch (e: Exception) {
+                Timber.d("Failed to log in user with email: $email")
+                _error.postValue(loginTask.exception?.localizedMessage)
+                cancel()
             }
+
+            // At this point, we are successfully logged in,
+            // we need to get the Firestore record associated with this email
+            // NOTE: We are guaranteed only one record in Firestore cus otherwise,
+            // this user would've failed signup
+
+            // This task returns a max of 1 doc
+            val userDocTask = authRepository.getFromFirestore(email)
+            try {
+                val userDoc = Tasks.await(userDocTask).documents[0]
+                Timber.d("Successfully got user doc with email: $email")
+                _user.value?.id = userDoc.id
+                _user.value?.email = userDoc.data?.get("email") as String
+                _user.value?.name = userDoc.data?.get("name") as String
+            } catch (e: Exception) {
+                Timber.d("Failed to get user doc with email: $email")
+                _error.postValue(userDocTask.exception?.localizedMessage)
+                cancel()
+            }
+
+            // At this point we've setup our _user variable
+            // and we can navigate away :)
+            _navigateToAuthenticated.postValue(true)
+
         }
     }
 
@@ -81,7 +101,6 @@ class AuthViewModel @Inject constructor(private val authRepository: AuthReposito
         // secondly, make a call to FirebaseFirestore using email and name to create a record
 
         viewModelScope.launch(Dispatchers.IO) {
-            val userModel = UserModel()
             // Try to sign up using FirebaseAuth
             val signupTask = authRepository.signup(email = email, password = password)
             try {
@@ -103,9 +122,9 @@ class AuthViewModel @Inject constructor(private val authRepository: AuthReposito
                 Timber.d("Successfully stored user with name: $name, email: $email")
                 Timber.d("Document created with id: ${doc.id}")
                 val docData = Tasks.await(doc.get())
-                userModel.id = docData.id
-                userModel.name = docData.data?.get("name") as String?
-                userModel.email = docData.data?.get("email") as String?
+                _user.value?.id = docData.id
+                _user.value?.name = docData.data?.get("name") as String?
+                _user.value?.email = docData.data?.get("email") as String?
             } catch (e: FirebaseFirestoreException) {
                 // something went wrong writing user
                 Timber.d("Failed to write user with name: $name, email: $email")
@@ -115,7 +134,6 @@ class AuthViewModel @Inject constructor(private val authRepository: AuthReposito
 
             // At this point we've setup our _user variable
             // and we can navigate away :)
-            _user.postValue(userModel)
             _navigateToAuthenticated.postValue(true)
 
         }

--- a/app/src/main/java/com/aa/draftt/auth/viewmodels/AuthViewModel.kt
+++ b/app/src/main/java/com/aa/draftt/auth/viewmodels/AuthViewModel.kt
@@ -123,11 +123,7 @@ class AuthViewModel @Inject constructor(private val authRepository: AuthReposito
 
     // updates the current user live data
     private fun currentUser(): FirebaseUser? {
-
-        return runBlocking {
-            authRepository.currentUser()
-        }
-
+        return runBlocking { authRepository.currentUser() }
     }
 
 }

--- a/app/src/main/java/com/aa/draftt/auth/viewmodels/AuthViewModel.kt
+++ b/app/src/main/java/com/aa/draftt/auth/viewmodels/AuthViewModel.kt
@@ -4,12 +4,17 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.aa.draftt.models.AuthResult
+import com.aa.draftt.models.UserModel
 import com.aa.draftt.auth.repositories.AuthRepository
-import com.aa.draftt.auth.repositories.AuthResult
+import com.google.android.gms.tasks.Tasks
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.FirebaseFirestoreException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -17,12 +22,27 @@ import javax.inject.Inject
 class AuthViewModel @Inject constructor(private val authRepository: AuthRepository) :
     ViewModel() {
 
+    // Tell the observing fragment to navigate away
+    private val _navigateToAuthenticated = MutableLiveData(false)
+    val navigateToAuthenticated: LiveData<Boolean>
+        get() = _navigateToAuthenticated
+
     // Stores results of making login/signup calls
     private val _authResult = MutableLiveData(
         AuthResult(status = null, error = null)
     )
     val authResult: LiveData<AuthResult>
         get() = _authResult
+
+    // Store user info using our model
+    private val _user = MutableLiveData<UserModel>()
+    val user: LiveData<UserModel>
+        get() = _user
+
+    // For observing error
+    private val _error = MutableLiveData<String>()
+    val error: LiveData<String>
+        get() = _error
 
     // Stores current logged in user
     private val _firebaseUser = MutableLiveData<FirebaseUser>(currentUser())
@@ -54,32 +74,60 @@ class AuthViewModel @Inject constructor(private val authRepository: AuthReposito
         }
     }
 
-    fun signup(email: String, password: String) {
+    fun signup(name: String, email: String, password: String) {
+
+        // We need to do 2 things here
+        // firstly, make a call to FirebaseAuth using email and password
+        // secondly, make a call to FirebaseFirestore using email and name to create a record
+
         viewModelScope.launch(Dispatchers.IO) {
-            val task = authRepository.signup(email, password)
-            task.addOnCompleteListener {
-                if (task.isSuccessful) {
-                    Timber.d("Successfully signed up user with email: $email")
-                    // Instead of posting the value of it.result!!.user, we need to get it from db
-                    _firebaseUser.postValue(it.result!!.user)
-                    _authResult.postValue(AuthResult(status = true, error = null))
-                } else {
-                    Timber.d("Failed to sign up user with email: $email")
-                    _firebaseUser.postValue(null)
-                    _authResult.postValue(
-                        AuthResult(
-                            status = false,
-                            error = task.exception?.localizedMessage.toString()
-                        )
-                    )
-                }
+            val userModel = UserModel()
+            // Try to sign up using FirebaseAuth
+            val signupTask = authRepository.signup(email = email, password = password)
+            try {
+                Tasks.await(signupTask)
+                Timber.d("Successfully signed up user with email: $email")
+            } catch (e: Exception) {
+                Timber.d("Something went wrong signing up user with email: $email")
+                _error.postValue(signupTask.exception?.localizedMessage)
+                cancel()
             }
+
+            // At this point, user is signed up from FirebaseAuth
+            // We need to store user info in FirebaseFirestore
+            // Try to sign up using FirebaseAuth
+            val fireStoreWriteTask = authRepository.writeToFirestore(name = name, email = email)
+            try {
+                // This stuff should really be in a firestore repository
+                val doc = Tasks.await(fireStoreWriteTask)
+                Timber.d("Successfully stored user with name: $name, email: $email")
+                Timber.d("Document created with id: ${doc.id}")
+                val docData = Tasks.await(doc.get())
+                userModel.id = docData.id
+                userModel.name = docData.data?.get("name") as String?
+                userModel.email = docData.data?.get("email") as String?
+            } catch (e: FirebaseFirestoreException) {
+                // something went wrong writing user
+                Timber.d("Failed to write user with name: $name, email: $email")
+                _error.postValue(fireStoreWriteTask.exception?.localizedMessage)
+                cancel()
+            }
+
+            // At this point we've setup our _user variable
+            // and we can navigate away :)
+            _user.postValue(userModel)
+            _navigateToAuthenticated.postValue(true)
+
         }
     }
 
     // updates the current user live data
     private fun currentUser(): FirebaseUser? {
-        return authRepository.currentUser()
+
+        return runBlocking {
+            authRepository.currentUser()
+        }
+
     }
 
 }

--- a/app/src/main/java/com/aa/draftt/auth/views/AuthActivity.kt
+++ b/app/src/main/java/com/aa/draftt/auth/views/AuthActivity.kt
@@ -21,7 +21,7 @@ class AuthActivity : AppCompatActivity() {
         // shared view model
         viewModel = ViewModelProvider(this).get(AuthViewModel::class.java)
 
-        if (viewModel.firebaseUser.value != null) {
+        if (viewModel.user.value?.id != null) {
             // user logged in
             // Go on to Home Activity
             Timber.d("User logged in")

--- a/app/src/main/java/com/aa/draftt/auth/views/LoginFragment.kt
+++ b/app/src/main/java/com/aa/draftt/auth/views/LoginFragment.kt
@@ -53,6 +53,8 @@ class LoginFragment : Fragment() {
                     // before we are ready to navigate, write user shizzle to sharefPref
                     writeUserToSharedPref(viewModel.user.value)
 
+                    startHomeActivity()
+
                     val intent = Intent(requireContext(), HomeActivity::class.java)
                     // These flags clear all activities on the stack
                     intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
@@ -67,6 +69,14 @@ class LoginFragment : Fragment() {
             binding.progressbar.visibility = View.GONE
         })
 
+    }
+
+    private fun startHomeActivity(){
+        val intent = Intent(requireContext(), HomeActivity::class.java)
+        // These flags clear all activities on the stack
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        startActivity(intent)
+        requireActivity().finish()
     }
 
     private fun writeUserToSharedPref(user: UserModel?) {

--- a/app/src/main/java/com/aa/draftt/auth/views/LoginFragment.kt
+++ b/app/src/main/java/com/aa/draftt/auth/views/LoginFragment.kt
@@ -67,36 +67,6 @@ class LoginFragment : Fragment() {
             binding.progressbar.visibility = View.GONE
         })
 
-
-//        viewModel.authResult.observe(viewLifecycleOwner, { authResult ->
-//            when (authResult.status) {
-//                true -> {
-//                    Timber.d("Successfully called Login API")
-//                }
-//                false -> {
-//                    Timber.d("Failed to call Login API")
-//                    Toast.makeText(
-//                        requireContext(),
-//                        authResult.error,
-//                        Toast.LENGTH_LONG
-//                    ).show()
-//                    binding.progressbar.visibility = View.GONE
-//                }
-//            }
-//        })
-//
-//        viewModel.firebaseUser.observe(viewLifecycleOwner, { user ->
-//            if (user != null) {
-//                Toast.makeText(
-//                    requireContext(),
-//                    "Logged in user with email: ${user.email}",
-//                    Toast.LENGTH_LONG
-//                ).show()
-//                writeUserToSharedPref(null)
-//            } else {
-//                writeUserToSharedPref(null)
-//            }
-//        })
     }
 
     private fun writeUserToSharedPref(user: UserModel?) {

--- a/app/src/main/java/com/aa/draftt/auth/views/SignupFragment.kt
+++ b/app/src/main/java/com/aa/draftt/auth/views/SignupFragment.kt
@@ -52,11 +52,8 @@ class SignupFragment : Fragment() {
                     // before we are ready to navigate, write user shizzle to sharefPref
                     writeUserToSharedPref(viewModel.user.value)
 
-                    val intent = Intent(requireContext(), HomeActivity::class.java)
-                    // These flags clear all activities on the stack
-                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                    startActivity(intent)
-                    requireActivity().finish()
+                    startHomeActivity()
+
                 }
             }
         })
@@ -66,6 +63,14 @@ class SignupFragment : Fragment() {
             binding.progressbar.visibility = View.GONE
         })
 
+    }
+
+    private fun startHomeActivity(){
+        val intent = Intent(requireContext(), HomeActivity::class.java)
+        // These flags clear all activities on the stack
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        startActivity(intent)
+        requireActivity().finish()
     }
 
     private fun writeUserToSharedPref(user: UserModel?) {

--- a/app/src/main/java/com/aa/draftt/auth/views/SignupFragment.kt
+++ b/app/src/main/java/com/aa/draftt/auth/views/SignupFragment.kt
@@ -44,20 +44,21 @@ class SignupFragment : Fragment() {
     private fun setupLiveDataObservers() {
 
         viewModel.navigateToAuthenticated.observe(viewLifecycleOwner, { navigate ->
-            if (navigate) {
-                Timber.d("Successfully signed up! and about to navigate away")
-                binding.progressbar.visibility = View.GONE
+            when (navigate) {
+                true -> {
+                    Timber.d("Successfully signed up! and about to navigate away")
+                    binding.progressbar.visibility = View.GONE
 
-                // before we are ready to navigate, write user shizzle to sharefPref
-                writeUserToSharedPref(viewModel.user.value)
+                    // before we are ready to navigate, write user shizzle to sharefPref
+                    writeUserToSharedPref(viewModel.user.value)
 
-                val intent = Intent(requireContext(), HomeActivity::class.java)
-                // These flags clear all activities on the stack
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                startActivity(intent)
-                requireActivity().finish()
+                    val intent = Intent(requireContext(), HomeActivity::class.java)
+                    // These flags clear all activities on the stack
+                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                    startActivity(intent)
+                    requireActivity().finish()
+                }
             }
-
         })
 
         viewModel.error.observe(viewLifecycleOwner, { error ->

--- a/app/src/main/java/com/aa/draftt/auth/views/SignupFragment.kt
+++ b/app/src/main/java/com/aa/draftt/auth/views/SignupFragment.kt
@@ -76,8 +76,8 @@ class SignupFragment : Fragment() {
             ) ?: return
             with(sharedPref.edit()) {
                 putString(getString(R.string.SHARED_PREF_USER_EMAIL_KEY), user.email)
-                putString("USER_NAME", user.name)
-                putString("USER_Id", user.id)
+                putString(getString(R.string.SHARED_PREF_USER_NAME_KEY), user.name)
+                putString(getString(R.string.SHARED_PREF_USER_ID_KEY), user.id)
                 apply()
             }
         }

--- a/app/src/main/java/com/aa/draftt/auth/views/SignupFragment.kt
+++ b/app/src/main/java/com/aa/draftt/auth/views/SignupFragment.kt
@@ -1,6 +1,7 @@
 package com.aa.draftt.auth.views
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.text.SpannableString
 import android.text.Spanned
@@ -19,6 +20,7 @@ import com.aa.draftt.Utils
 import com.aa.draftt.models.UserModel
 import com.aa.draftt.auth.viewmodels.AuthViewModel
 import com.aa.draftt.databinding.FragmentSignupBinding
+import com.aa.draftt.views.HomeActivity
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 
@@ -45,11 +47,11 @@ class SignupFragment : Fragment() {
             Timber.d("Successfully signed up! and about to navigate away")
             binding.progressbar.visibility = View.GONE
 
-//            val intent = Intent(requireContext(), HomeActivity::class.java)
-//            // These flags clear all activities on the stack
-//            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-//            startActivity(intent)
-//            requireActivity().finish()
+            val intent = Intent(requireContext(), HomeActivity::class.java)
+            // These flags clear all activities on the stack
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            startActivity(intent)
+            requireActivity().finish()
         })
 
         viewModel.error.observe(viewLifecycleOwner, { error ->

--- a/app/src/main/java/com/aa/draftt/hilt/DrafttModule.kt
+++ b/app/src/main/java/com/aa/draftt/hilt/DrafttModule.kt
@@ -9,6 +9,8 @@ import com.aa.draftt.room.DrafttDatabase
 import com.aa.draftt.room.dao.UserDao
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import dagger.Binds
 import dagger.Module
@@ -26,6 +28,12 @@ class DrafttProvidesModule {
     @Singleton
     fun providesFirebaseAuthService(): FirebaseAuth {
         return Firebase.auth
+    }
+
+    @Provides
+    @Singleton
+    fun providesFirebaseFirestore(): FirebaseFirestore {
+        return Firebase.firestore
     }
 
     @Provides

--- a/app/src/main/java/com/aa/draftt/models/AuthResult.kt
+++ b/app/src/main/java/com/aa/draftt/models/AuthResult.kt
@@ -1,4 +1,4 @@
-package com.aa.draftt.auth.models
+package com.aa.draftt.models
 
 // the user can be yeeted from this class
 data class AuthResult(val status: Boolean?, val error: String?)

--- a/app/src/main/java/com/aa/draftt/models/AuthResult.kt
+++ b/app/src/main/java/com/aa/draftt/models/AuthResult.kt
@@ -1,4 +1,4 @@
-package com.aa.draftt.auth.repositories
+package com.aa.draftt.auth.models
 
 // the user can be yeeted from this class
 data class AuthResult(val status: Boolean?, val error: String?)

--- a/app/src/main/java/com/aa/draftt/models/UserModel.kt
+++ b/app/src/main/java/com/aa/draftt/models/UserModel.kt
@@ -1,0 +1,7 @@
+package com.aa.draftt.models
+
+data class UserModel(
+    var id: String? = null,
+    var name: String? = null,
+    var email: String? = null
+)

--- a/app/src/main/java/com/aa/draftt/views/HomeFragment.kt
+++ b/app/src/main/java/com/aa/draftt/views/HomeFragment.kt
@@ -42,8 +42,8 @@ class HomeFragment @Inject constructor(): Fragment() {
         ) ?: null
 
         val loggedUser = sharedPref?.getString(getString(R.string.SHARED_PREF_USER_EMAIL_KEY), "Could not get user email from shared pref")
-        val userName = sharedPref?.getString("USER_NAME", "Could not get user name from shared pref")
-        val userID = sharedPref?.getString("USER_Id", "Could not get user id from shared pref")
+        val userName = sharedPref?.getString(getString(R.string.SHARED_PREF_USER_NAME_KEY), "Could not get user name from shared pref")
+        val userID = sharedPref?.getString(getString(R.string.SHARED_PREF_USER_ID_KEY), "Could not get user id from shared pref")
         Toast.makeText(requireContext(), "$loggedUser, $userName, $userID", Toast.LENGTH_SHORT).show()
 
         setupListeners()

--- a/app/src/main/java/com/aa/draftt/views/HomeFragment.kt
+++ b/app/src/main/java/com/aa/draftt/views/HomeFragment.kt
@@ -42,7 +42,9 @@ class HomeFragment @Inject constructor(): Fragment() {
         ) ?: null
 
         val loggedUser = sharedPref?.getString(getString(R.string.SHARED_PREF_USER_EMAIL_KEY), "Could not get user email from shared pref")
-        Toast.makeText(requireContext(), loggedUser, Toast.LENGTH_SHORT).show()
+        val userName = sharedPref?.getString("USER_NAME", "Could not get user name from shared pref")
+        val userID = sharedPref?.getString("USER_Id", "Could not get user id from shared pref")
+        Toast.makeText(requireContext(), "$loggedUser, $userName, $userID", Toast.LENGTH_SHORT).show()
 
         setupListeners()
 

--- a/app/src/main/res/values-night/strings.xml
+++ b/app/src/main/res/values-night/strings.xml
@@ -2,4 +2,6 @@
 <resources>
     <string name="SHARED_PREF_USER_EMAIL_KEY">USER_EMAIL</string>
     <string name="SHARED_PREF_FILE_KEY">com.aa.draftt.PREFERENCE_FILE_KEY</string>
+    <string name="SHARED_PREF_USER_NAME_KEY">USER_NAME</string>
+    <string name="SHARED_PREF_USER_ID_KEY">USER_Id</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,4 +39,6 @@
     <string name="team_name_button">Let\'s go!</string>
     <string name="SHARED_PREF_USER_EMAIL_KEY">USER_EMAIL</string>
     <string name="SHARED_PREF_FILE_KEY">com.aa.draftt.PREFERENCE_FILE_KEY</string>
+    <string name="SHARED_PREF_USER_NAME_KEY">USER_NAME</string>
+    <string name="SHARED_PREF_USER_ID_KEY">USER_Id</string>
 </resources>


### PR DESCRIPTION
# What
did a lot of stuff in this PR but here's the summary

- Added Firestore shizzle
- Updated all auth thingys so that firestore is used
  - on `signup`, add document to `users` collection
  - on `login`, if firebase authenticates user, get info from firestore
- Updated all fragments to listen to new viewmodel vars
  - the old ones have been removed
- Added some coroutines dependencies 


TODO: 
- remove `AuthResult` from models 
- Move repositories out of `Auth` package

Closes #64 